### PR TITLE
Fix hot reload for JS and YAML files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,10 +125,7 @@ const serve = function() {
   });
 
   // Recompile templates if any content changes.
-  watch(
-    ['src/pages/**/*.html', 'src/templates/**/*.twig', 'src/data/**/*.json'],
-    series(html, reload),
-  );
+  watch(['src/pages/**/*', 'src/templates/**/*', 'src/data/**/*'], series(html, reload));
 
   // Trigger static task when files in the public directory are changed.
   watch('public/**/*', series(publicFiles, reload));


### PR DESCRIPTION
- Ensure watch task detects changes to non-json data files