### PR TITLE
Fork menu.twig from base.twig

### DIFF
--- a/src/pages/example.html
+++ b/src/pages/example.html
@@ -2,7 +2,7 @@
 ## Note: all fields are optional except for title
 
 title: Example Page
-description: The example page description goes here.  A custom thumbnail is set for this page.
+description: The example page description goes here. A custom thumbnail is set for this page.
 updated: Updated Feb. 28, 2020
 thumbnail: custom-thumbnail.png
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -5,64 +5,58 @@ title: Prototype Index
 thumbnail: false
 ---
 
-{% extends "@templates/layouts/base.twig" %}
+{% extends "@templates/layouts/menu.twig" %}
 
 {% set config = site.data['menu.json'] %}
 {% set groupedPages = site.pages|group('group') %}
 {% set ungroupedPages = groupedPages['undefined']|default([]) %}
 
-{% block styles %}
-<link rel="stylesheet" type="text/css" href="{{ puppy.assetUrl('menu.css') }}">
-{% endblock %}
-
-{% block header %}
-<header class="home-header">
-  <div class="home-header__ups-lockup">
+{% block content %}
+<header class="menu-header">
+  <div class="menu-header__ups-lockup">
     {% if config.logo %}
     <img class="logo" src="{{ config.logo.url }}" alt="{{ config.logo.alt | default('') }}" />
     {% endif %}
 
     {% if config.header_links|length %}
-    <nav class="home-header__outlinks">
-      <ul class="home-header__outlinks-list">
+    <nav class="menu-header__outlinks">
+      <ul class="menu-header__outlinks-list">
         {% for link in config.header_links %}
-        <li class="home-header__outlinks-item">
-          <a class="home-header__outlinks-link" href="{{ link.url }}">{{ link.label }}</a>
+        <li class="menu-header__outlinks-item">
+          <a class="menu-header__outlinks-link" href="{{ link.url }}">{{ link.label }}</a>
         </li>
         {% endfor %}
       </ul>
     </nav>
     {% endif %}
   </div>
-  <h1 class="home-header__title">{{ page.title }}</h1>
+  <h1 class="menu-header__title">{{ page.title }}</h1>
 </header>
-{% endblock %}
 
-{% block content %}
-<nav class="home-menu">
+<nav class="menu-content">
 
   {% if ungroupedPages is not empty %}
-  <ul class="home-menu__list">
+  <ul class="menu-content__list">
 
     {% for p in ungroupedPages if p.path != page.path and p.menu != false %}
       {% set thumbnail = p.thumbnail matches '/auto/i' ? p.screenshot : p.thumbnail %}
-      <li class="home-menu__item{% if p.thumbnail %} home-menu__item--has-thumbnail{% else %} home-menu__item--no-thumbnail{% endif %}">
-        <a class="home-menu__link" href="{{ puppy.url(p) }}">
+      <li class="menu-content__item{% if p.thumbnail %} menu-content__item--has-thumbnail{% else %} menu-content__item--no-thumbnail{% endif %}">
+        <a class="menu-content__link" href="{{ puppy.url(p) }}">
 
           {% if thumbnail %}
-          <div class="home-menu__images">
+          <div class="menu-content__images">
             <img src="{{ puppy.siteUrl('thumbnails/' ~ thumbnail) }}" alt="{{ p.title }}" />
           </div>
           {% endif %}
 
-          <div class="home-menu__text">
-            <div class="home-menu__text-inner">
-              <h2 class="home-menu__title">{{ p.title }}</h2>
+          <div class="menu-content__text">
+            <div class="menu-content__text-inner">
+              <h2 class="menu-content__title">{{ p.title }}</h2>
               {% if p.updated %}
-                <h4 class="home-menu__updated">{{ p.updated }}</h4>
+                <h4 class="menu-content__updated">{{ p.updated }}</h4>
               {% endif %}
               {% if p.description %}
-                <p class="home-menu__description">{{ p.description }}</p>
+                <p class="menu-content__description">{{ p.description }}</p>
               {% endif %}
               {% if thumbnail %}
                 {% include '@templates/svgs/menu/circle-arrow.twig' %}
@@ -71,7 +65,7 @@ thumbnail: false
           </div>
 
           {% if not thumbnail %}
-            <div class="home-menu__images">
+            <div class="menu-content__images">
               {% include '@templates/svgs/menu/circle-arrow.twig' %}
             </div>
           {% endif %}
@@ -84,21 +78,21 @@ thumbnail: false
   {% endif %}
 
   {% for group, pages in groupedPages if group != 'undefined' %}
-    <section class="home-menu__group">
-      <h3 class="home-menu__group-head">{{ group }}</h3>
-      <ul class="home-menu__group-pages">
+    <section class="menu-content__group">
+      <h3 class="menu-content__group-head">{{ group }}</h3>
+      <ul class="menu-content__group-pages">
       {% for p in pages if p.path != page.path and p.menu != false %}
         {% set thumbnail = p.thumbnail matches '/auto/i' ? p.screenshot : p.thumbnail %}
-        <li class="home-menu__group-item">
-          <a href="{{ puppy.url(p) }} " class="home-menu__group-item-link">
+        <li class="menu-content__group-item">
+          <a href="{{ puppy.url(p) }} " class="menu-content__group-item-link">
             {% if thumbnail %}
-              <img class="home-menu__small-thumb" src="{{ puppy.siteUrl('thumbnails/' ~ thumbnail) }}" alt="{{ p.title }}" />
+              <img class="menu-content__small-thumb" src="{{ puppy.siteUrl('thumbnails/' ~ thumbnail) }}" alt="{{ p.title }}" />
             {% endif %}
-            <div class="home-menu__small-text">
-              <div class="home-menu__small-text-inner">
-                <h2 class="home-menu__small-title">{{ p.title }}</h2>
+            <div class="menu-content__small-text">
+              <div class="menu-content__small-text-inner">
+                <h2 class="menu-content__small-title">{{ p.title }}</h2>
                 {% if p.updated %}
-                  <h4 class="home-menu__small-updated">{{ p.updated }}</h4>
+                  <h4 class="menu-content__small-updated">{{ p.updated }}</h4>
                 {% endif %}
               </div>
               {% include '@templates/svgs/menu/circle-arrow.twig' %}
@@ -112,15 +106,10 @@ thumbnail: false
 
 </nav>
 
-
-{% endblock %}
-
-{% block footer %}
-<footer class="home-footer">
-  <div class="home-footer__inner">
+<footer class="menu-footer">
+  <div class="menu-footer__inner">
     <p><a href="https://github.com/Upstatement/puppy">Built with Puppy</a></p>
   </div>
 </footer>
-{% endblock %}
 
-{% block scripts %}{% endblock %}
+{% endblock %}

--- a/src/scss/menu.scss
+++ b/src/scss/menu.scss
@@ -120,7 +120,7 @@ body {
   min-height: 100vh;
 }
 
-.menu-content {
+.menu-wrap {
   background-color: $c-white;
 }
 

--- a/src/scss/menu.scss
+++ b/src/scss/menu.scss
@@ -5,7 +5,7 @@
 $bp-xs: 450px;
 $bp-sm: 600px;
 $bp-lg: 1000px;
-$home-max: 1200px;
+$menu-max: 1200px;
 
 $bp-split-thumbed-item: $bp-xs;
 $bp-split-header: $bp-sm;
@@ -21,7 +21,7 @@ $c-gray-light: #eaeaea;
 
 $sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
-@mixin home-pad {
+@mixin menu-pad {
   padding: 15px;
   @media (min-width: $bp-sm) {
     padding: 25px;
@@ -104,8 +104,8 @@ svg {
   max-width: 100%;
 }
 
-.home-menu__images,
-.home-menu__group-item-link {
+.menu-content__images,
+.menu-content__group-item-link {
   img {
     box-shadow: 0 0 5px rgba($c-black, 0.08);
   }
@@ -120,21 +120,21 @@ body {
   min-height: 100vh;
 }
 
-.home-content {
+.menu-content {
   background-color: $c-white;
 }
 
-.home-header,
-.home-menu,
-.home-footer__inner {
-  @include home-pad;
+.menu-header,
+.menu-content,
+.menu-footer__inner {
+  @include menu-pad;
   margin: 0 auto;
-  max-width: $home-max;
+  max-width: $menu-max;
   width: 100%;
 }
 
 // Home Header
-.home-header {
+.menu-header {
   @media (min-width: $bp-sm) {
     padding-top: 2rem;
   }
@@ -149,13 +149,13 @@ body {
   }
 }
 
-.home-header__title {
+.menu-header__title {
   @include header-title;
   color: $c-black;
   order: 1;
 }
 
-.home-header__ups-lockup {
+.menu-header__ups-lockup {
   margin-bottom: 2rem;
   order: 2;
   padding-top: 0.375rem;
@@ -176,13 +176,13 @@ body {
   }
 }
 
-.home-header__outlinks-list {
+.menu-header__outlinks-list {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-a.home-header__outlinks-link {
+a.menu-header__outlinks-link {
   color: $c-gray;
   display: block;
   font: 400 14px / 1 $sans;
@@ -194,23 +194,23 @@ a.home-header__outlinks-link {
   }
 }
 
-.home-menu {
+.menu-content {
   padding-bottom: 15rem;
 }
 
-.home-menu__list {
+.menu-content__list {
   list-style: none;
   margin: 0 0 100px;
   padding: 0;
 }
 
-.home-menu__item {
+.menu-content__item {
   &:first-of-type {
     border-top: 3px solid $c-black;
   }
 }
 
-.home-menu__link {
+.menu-content__link {
   border-bottom: 1px solid $c-gray-light;
   padding: 30px 0;
 
@@ -231,22 +231,22 @@ a.home-header__outlinks-link {
   }
 }
 
-.home-menu__text {
+.menu-content__text {
   flex-grow: 1;
   flex-shrink: 1;
 }
 
-.home-menu__images {
+.menu-content__images {
   flex-shrink: 0;
   text-align: right;
 }
 
-.home-menu__title {
+.menu-content__title {
   @include page-title-big;
   margin-bottom: 0.5rem;
 }
 
-.home-menu__small-title {
+.menu-content__small-title {
   @include page-title-small;
   margin-bottom: 0.5rem;
 
@@ -267,8 +267,8 @@ a.home-header__outlinks-link {
     width: 55px;
   }
 
-  .home-menu__item:hover &,
-  .home-menu__group-item:hover & {
+  .menu-content__item:hover &,
+  .menu-content__group-item:hover & {
     path:nth-child(1) {
       fill: $c-black;
     }
@@ -280,12 +280,12 @@ a.home-header__outlinks-link {
   }
 }
 
-.home-menu__updated {
+.menu-content__updated {
   @include updated;
   margin-bottom: 1rem;
 }
 
-.home-menu__description {
+.menu-content__description {
   @include description;
   @media (min-width: $bp-lg) {
     @include grid-width(2);
@@ -293,16 +293,16 @@ a.home-header__outlinks-link {
   }
 }
 
-.home-menu__item--no-thumbnail {
-  .home-menu__link {
+.menu-content__item--no-thumbnail {
+  .menu-content__link {
     align-items: stretch;
     display: flex;
     justify-content: space-between;
   }
 }
 
-.home-menu__item--has-thumbnail {
-  .home-menu__link {
+.menu-content__item--has-thumbnail {
+  .menu-content__link {
     display: block;
     @media (min-width: $bp-split-thumbed-item) {
       align-items: stretch;
@@ -311,7 +311,7 @@ a.home-header__outlinks-link {
     }
   }
 
-  .home-menu__text {
+  .menu-content__text {
     flex-grow: 1;
     order: 1;
     padding-right: 50px;
@@ -324,7 +324,7 @@ a.home-header__outlinks-link {
     }
   }
 
-  .home-menu__text-inner {
+  .menu-content__text-inner {
     align-items: stretch;
     display: flex;
     flex-direction: column;
@@ -336,7 +336,7 @@ a.home-header__outlinks-link {
     }
   }
 
-  .home-menu__description {
+  .menu-content__description {
     margin-bottom: 1rem;
     max-width: none;
     width: 100%;
@@ -345,7 +345,7 @@ a.home-header__outlinks-link {
     }
   }
 
-  .home-menu__images {
+  .menu-content__images {
     margin-bottom: 1rem;
     order: 2;
     @media (min-width: $bp-split-thumbed-item) {
@@ -358,20 +358,20 @@ a.home-header__outlinks-link {
 
 
 // Groups
-.home-menu__group {
+.menu-content__group {
   border-bottom: 1px solid $c-gray-light;
   margin-bottom: 100px;
 }
 
 
-.home-menu__group-head {
+.menu-content__group-head {
   border-bottom: 3px solid $c-black;
   font: 800 24px / 1.2 $sans;
   margin-bottom: $grid-gutter;
   padding-bottom: 0.25rem;
 }
 
-.home-menu__group-pages {
+.menu-content__group-pages {
   align-items: flex-start;
   display: flex;
   flex-wrap: wrap;
@@ -379,7 +379,7 @@ a.home-header__outlinks-link {
   margin-bottom: 20px;
 }
 
-.home-menu__group-item {
+.menu-content__group-item {
   @include grid-width(2);
   margin-bottom: $grid-gutter;
   margin-right: $grid-gutter;
@@ -402,15 +402,15 @@ a.home-header__outlinks-link {
 }
 
 
-.home-menu__group-item-link {
+.menu-content__group-item-link {
   display: block;
 
-  &:hover .home-menu__small-thumb {
+  &:hover .menu-content__small-thumb {
     opacity: 0.7;
   }
 }
 
-.home-menu__small-text {
+.menu-content__small-text {
   align-items: flex-start;
   display: flex;
   flex-wrap: nowrap;
@@ -424,30 +424,30 @@ a.home-header__outlinks-link {
   }
 }
 
-.home-menu__small-text-inner {
+.menu-content__small-text-inner {
   flex: 1 1 auto;
 }
 
-.home-menu__small-thumb {
+.menu-content__small-thumb {
   margin-bottom: $grid-gutter / 2;
 }
 
-.home-menu__small-title {
+.menu-content__small-title {
   @include page-title-small;
 }
 
-.home-menu__small-updated {
+.menu-content__small-updated {
   @include updated;
   margin-bottom: 0.5rem;
 }
 
-.home-menu__small-description {
+.menu-content__small-description {
   @include description;
   margin-bottom: $grid-gutter;
 }
 
 
-.home-footer {
+.menu-footer {
   background-color: $c-black;
   margin-top: auto;
 

--- a/src/templates/layouts/menu.twig
+++ b/src/templates/layouts/menu.twig
@@ -6,19 +6,11 @@
     <title>{{ page.title }}</title>
     <meta name="description" content="{{ page.description | e('html_attr') }}">
     {% block meta %}{% endblock %}
-
-    {% block styles %}
-    <link rel="stylesheet" type="text/css" href="{{ puppy.assetUrl('main.css') }}">
-    {% endblock %}
+    <link rel="stylesheet" type="text/css" href="{{ puppy.assetUrl('menu.css') }}">
   </head>
   <body>
-    <div class="site-content">
+    <div class="menu-content">
       {% block content %}{% endblock %}
     </div>
-
-    {% block scripts %}
-    <script type="text/javascript" src="{{ puppy.assetUrl('vendor.js') }}"></script>
-    <script type="text/javascript" src="{{ puppy.assetUrl('main.js') }}"></script>
-    {% endblock %}
   </body>
 </html>

--- a/src/templates/layouts/menu.twig
+++ b/src/templates/layouts/menu.twig
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" href="{{ puppy.assetUrl('menu.css') }}">
   </head>
   <body>
-    <div class="menu-content">
+    <div class="menu-wrap">
       {% block content %}{% endblock %}
     </div>
   </body>


### PR DESCRIPTION
- Adds a `menu.twig` template and changes `index.html` to extend it. The intended benefit is that more complex sites may require customization of base.twig (e.g. meta tags, additional scripts, inline CSS)which logically have nothing to do the Prototype index.
- Updates the class names used in index.html and menu.scss for clarity
- Removes a double-space from an example description 😱 

## To Test

1. Confirm changes to main.scss still only affects styles in example pages, not the menu/index page.