### PR TITLE
Design tune-up

### DIFF
--- a/src/pages/example.html
+++ b/src/pages/example.html
@@ -2,7 +2,7 @@
 ## Note: all fields are optional except for title
 
 title: Example Page
-description: The example page description goes here.  A custom thumbnail is set for this page.
+description: The example page description goes here. A custom thumbnail is set for this page. The example page description goes here.
 updated: Updated Feb. 28, 2020
 thumbnail: custom-thumbnail.png
 ---

--- a/src/pages/example.html
+++ b/src/pages/example.html
@@ -2,7 +2,7 @@
 ## Note: all fields are optional except for title
 
 title: Example Page
-description: The example page description goes here. A custom thumbnail is set for this page. The example page description goes here.
+description: The example page description goes here. A custom thumbnail is set for this page.
 updated: Updated Feb. 28, 2020
 thumbnail: custom-thumbnail.png
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -58,11 +58,11 @@ thumbnail: false
           <div class="home-menu__text">
             <div class="home-menu__text-inner">
               <h2 class="home-menu__title">{{ p.title }}</h2>
-              {% if p.updated %}
-                <h4 class="home-menu__updated">{{ p.updated }}</h4>
-              {% endif %}
               {% if p.description %}
                 <p class="home-menu__description">{{ p.description }}</p>
+              {% endif %}
+              {% if p.updated %}
+                <h4 class="home-menu__updated">{{ p.updated }}</h4>
               {% endif %}
               {% if thumbnail %}
                 {% include '@templates/svgs/menu/circle-arrow.twig' %}

--- a/src/scss/menu.scss
+++ b/src/scss/menu.scss
@@ -4,6 +4,7 @@
 // Home vars
 $bp-xs: 450px;
 $bp-sm: 600px;
+$bp-md: 760px;
 $bp-lg: 1000px;
 $home-max: 1200px;
 
@@ -38,7 +39,7 @@ $sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 @mixin header-title {
   font: 400 28px / 1.25 $sans;
-  letter-spacing: 0.1rem;
+  letter-spacing: 0.01rem;
   @media (min-width: $bp-sm) {
     font-size: 36px;
   }
@@ -48,8 +49,8 @@ $sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 @mixin page-title-big {
-  font: 200 21px / 1.25 $sans;
-  letter-spacing: 0.03rem;
+  font: 400 21px / 1.25 $sans;
+  letter-spacing: 0.01rem;
 
   @media (min-width: $bp-sm) {
     font-size: 28px;
@@ -61,7 +62,7 @@ $sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 @mixin page-title-small {
   font: 400 18px / 1.25 $sans;
-  letter-spacing: 0.03rem;
+  letter-spacing: 0.01rem;
 }
 
 @mixin updated {
@@ -71,12 +72,17 @@ $sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 @mixin description {
-  color: $c-gray;
+  // color: $c-gray;
   font: 400 13px / 1.5 $sans;
 
   @media (min-width: $bp-lg) {
     font-size: 15px;
   }
+}
+
+@mixin size($w, $h:$w) {
+  height: $h;
+  width: $w;
 }
 
 // Menu Styles
@@ -102,12 +108,20 @@ img,
 svg {
   display: block;
   max-width: 100%;
+  transition: 0.1s ease;
 }
+
+
 
 .home-menu__images,
 .home-menu__group-item-link {
   img {
-    box-shadow: 0 0 5px rgba($c-black, 0.08);
+    box-shadow: 0 0 10px rgba($c-black, 0.07);
+  }
+
+  &:hover img {
+    box-shadow: 0 0 20px rgba($c-black, 0.04);
+    transform: scale(1.01);
   }
 }
 
@@ -225,11 +239,12 @@ a.home-header__outlinks-link {
   &:hover {
     img {
       display: block;
-      opacity: 0.7;
       width: 100%;
     }
   }
 }
+
+
 
 .home-menu__text {
   flex-grow: 1;
@@ -253,18 +268,12 @@ a.home-header__outlinks-link {
 }
 
 .circle-arrow {
-  height: 30px;
-  transform: translateX(-2.5px);
-  width: 30px;
-  @media (min-width: $bp-sm) {
-    height: 40px;
-    transform: translateX(-4px);
-    width: 40px;
+  @include size(30px);
+  @media (min-width: $bp-md) {
+    @include size(40px);
   }
   @media (min-width: $bp-lg) {
-    height: 55px;
-    transform: translateX(-5px);
-    width: 55px;
+    @include size(55px);
   }
 
   .home-menu__item:hover &,
@@ -404,23 +413,19 @@ a.home-header__outlinks-link {
 
 .home-menu__group-item-link {
   display: block;
-
-  &:hover .home-menu__small-thumb {
-    opacity: 0.7;
-  }
 }
 
 .home-menu__small-text {
-  align-items: flex-start;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
+  @media (min-width: $bp-md) {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
 
-  .circle-arrow {
-    flex-shrink: 0;
-    height: 40px;
-    margin-left: $grid-gutter;
-    width: 40px;
+    .circle-arrow {
+      flex-shrink: 0;
+      margin-left: $grid-gutter;
+    }
   }
 }
 

--- a/src/scss/menu.scss
+++ b/src/scss/menu.scss
@@ -68,13 +68,11 @@ $sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 @mixin updated {
   color: $c-red;
   font: 400 12px / 1.5 $sans;
-  letter-spacing: 0.02rem;
+  letter-spacing: 0.01rem;
 }
 
 @mixin description {
-  // color: $c-gray;
   font: 400 13px / 1.5 $sans;
-
   @media (min-width: $bp-lg) {
     font-size: 15px;
   }
@@ -296,6 +294,7 @@ a.home-header__outlinks-link {
 
 .home-menu__description {
   @include description;
+  margin-bottom: 1rem;
   @media (min-width: $bp-lg) {
     @include grid-width(2);
     font-size: 15px;
@@ -345,13 +344,11 @@ a.home-header__outlinks-link {
     }
   }
 
+
   .home-menu__description {
     margin-bottom: 1rem;
     max-width: none;
     width: 100%;
-    @media (min-width: $bp-split-thumbed-item) {
-      margin-bottom: 0;
-    }
   }
 
   .home-menu__images {
@@ -443,7 +440,6 @@ a.home-header__outlinks-link {
 
 .home-menu__small-updated {
   @include updated;
-  margin-bottom: 0.5rem;
 }
 
 .home-menu__small-description {


### PR DESCRIPTION
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/1659785/80828351-1ec73500-8bb3-11ea-9f61-6f18416e4a2b.png">

## What this does

- Tweaks some font weights 
- Sets the description text back to black
- Moves `updated` line below description
- Fixes a bug where the arrows were not sized consistently on mobile
- Adds a slight screenshot scale when hovering over a page link

## To Test

1. Load up the index and check the styles on mobile and desktop
