### PR TITLE
Fix thumbnail image jump during hover

### DIFF
--- a/src/scss/menu.scss
+++ b/src/scss/menu.scss
@@ -107,6 +107,7 @@ svg {
   display: block;
   max-width: 100%;
   transition: 0.1s ease;
+  width: 100%;
 }
 
 


### PR DESCRIPTION
## Issue
When the thumbnail image is smaller than the container, it will cause a size jump when you hover, because the width attribute is missing for the `<img>` tag.

![ezgif-5-67505ce7e371](https://user-images.githubusercontent.com/50229745/92744303-5dce7980-f34f-11ea-9656-758e90152b13.gif)

## the fix
![92677419-d272cb00-f2f1-11ea-97af-eb369f7abf33](https://user-images.githubusercontent.com/50229745/92744604-9ff7bb00-f34f-11ea-9001-46de0254f298.png)